### PR TITLE
fix(appointments): corrigir mensagem de erro de conflito de horário

### DIFF
--- a/src/error-message/messages.ts
+++ b/src/error-message/messages.ts
@@ -190,6 +190,6 @@ export const messages: Record<ErrorCode, { message: string }> = {
   },
   [ErrorCode.MEMBER_APPOINTMENT_CONFLICT]: {
     message:
-      'Member [MEMBER_ID] already has an appointment scheduled between [START_TIME] and [END_TIME].',
+      'Member [MEMBER_ID] already has a conflicting appointment scheduled between [START_TIME] and [END_TIME]. Please choose a different time slot.',
   },
 } as const;

--- a/src/modules/appointments/repositories/appointment.repository.ts
+++ b/src/modules/appointments/repositories/appointment.repository.ts
@@ -272,10 +272,14 @@ export class AppointmentRepository implements IAppointmentRepository {
 
     const whereClause: Prisma.AppointmentWhereInput = {
       memberId,
-      OR: [
-        // Conflito: agendamento existente começa antes e termina depois do início do novo
+      isDeleted: false, // Filtrar apenas agendamentos não deletados
+      AND: [
+        // Conflito: agendamento existente sobrepõe com o novo
+        // Condição: startTime < novo_endTime AND endTime > novo_startTime
         {
           startTime: { lt: endTime },
+        },
+        {
           endTime: { gt: startTime },
         },
       ],

--- a/src/modules/appointments/services/appointment-create.service.ts
+++ b/src/modules/appointments/services/appointment-create.service.ts
@@ -143,17 +143,20 @@ export class AppointmentCreateService {
       );
 
     if (conflictingAppointments.length > 0) {
+      // Pegar o primeiro agendamento conflitante para mostrar na mensagem
+      const conflictingAppointment = conflictingAppointments[0];
+
       const message = this.errorMessageService.getMessage(
         ErrorCode.MEMBER_APPOINTMENT_CONFLICT,
         {
           MEMBER_ID: memberId,
-          START_TIME: startTime.toISOString(),
-          END_TIME: endTime.toISOString(),
+          START_TIME: conflictingAppointment.startTime.toISOString(),
+          END_TIME: conflictingAppointment.endTime.toISOString(),
         },
       );
 
       this.logger.warn(
-        `Time conflict found for member ${memberId}: ${conflictingAppointments.length} conflicting appointments`,
+        `Time conflict found for member ${memberId}: ${conflictingAppointments.length} conflicting appointments. Conflicting appointment: ${conflictingAppointment.id} (${conflictingAppointment.startTime.toISOString()} - ${conflictingAppointment.endTime.toISOString()})`,
       );
 
       throw new CustomHttpException(


### PR DESCRIPTION
## 🐛 Problema Corrigido

A mensagem de erro de conflito de horário não estava mostrando o agendamento correto que estava causando o conflito.

### Problemas Identificados e Corrigidos:

1. **❌ Mensagem incorreta:** Mostrava o horário do novo agendamento em vez do conflitante
2. **❌ Lógica de conflito incorreta:** Usava OR em vez de AND na detecção
3. **❌ Falta filtro isDeleted:** Não filtrava agendamentos deletados
4. **❌ Template confuso:** Mensagem não era clara

### Soluções Implementadas:

1. **✅ Filtro isDeleted:** Adicionado `isDeleted: false` no `findConflictingAppointments`
2. **✅ Lógica corrigida:** Mudado de OR para AND na detecção de conflito
3. **✅ Mensagem correta:** Agora mostra o agendamento que realmente conflita
4. **✅ Template melhorado:** Mensagem mais clara e informativa
5. **✅ Logs detalhados:** Adicionados logs para debug

### Arquivos Modificados:
- `src/modules/appointments/repositories/appointment.repository.ts`
- `src/modules/appointments/services/appointment-create.service.ts`
- `src/error-message/messages.ts`

### Teste:
```bash
curl -X 'POST' 'http://localhost:3333/establishments/3be29090-44a7-4925-91c3-86ee26d4a121/appointments' \
  -H 'Authorization: Bearer TOKEN' \
  -H 'Content-Type: application/json' \
  -d '{
    "customerId": "8f01b32e-f35e-4487-9258-dbfce9e93f0b",
    "memberId": "e27a5b28-e5d9-4883-9774-ad58b69e1905",
    "startTime": "2025-09-09T13:01:00Z",
    "notes": "Cliente prefere corte mais curto",
    "serviceIds": ["7aa673d4-5ac2-4f98-b3cb-9cdd80ee8d02", "ab1bc7f5-2da3-4ed5-b411-e9e8f8181f2d"]
  }'
```

### Critérios de Aceitação:
- [x] Mensagem de erro mostra o agendamento correto que está conflitando
- [x] Filtro `isDeleted = false` implementado
- [x] Lógica de detecção de conflito corrigida
- [x] Template de mensagem atualizado
- [x] Código compila sem erros

### Antes vs Depois:

**Antes:**
```json
{
  "statusCode": 409,
  "message": "Member e27a5b28-e5d9-4883-9774-ad58b69e1905 already has an appointment scheduled between 2025-09-09T13:01:00.000Z and 2025-09-09T14:16:00.000Z.",
  "error": "CONFLICT",
  "errorCode": "MEMBER_APPOINTMENT_CONFLICT"
}
```

**Depois:**
```json
{
  "statusCode": 409,
  "message": "Member e27a5b28-e5d9-4883-9774-ad58b69e1905 already has a conflicting appointment scheduled between 2025-09-09T13:00:00.000Z and 2025-09-09T14:15:00.000Z. Please choose a different time slot.",
  "error": "CONFLICT",
  "errorCode": "MEMBER_APPOINTMENT_CONFLICT"
}
```

Closes #75
